### PR TITLE
Restore deleted code

### DIFF
--- a/lib/Algebra/FunctionProperties/Eq.agda
+++ b/lib/Algebra/FunctionProperties/Eq.agda
@@ -570,7 +570,7 @@ module Implicits where
       -1*-neg : ∀ {x} → -1# * x ≡ 0− x
       -1*-neg = ! 0−-*-distr ♦ 0−= 1*-identity
 
-      2*-*-distr : ∀ {x y} → 2*(x * y) ≡ 2* x * y
+      2*-*-distr : ∀ {x y} → 2*(x * y) ≡ (2* x) * y
       2*-*-distr = ! *-+-distrʳ
 
     module From-+Group-*Identity-DistributesOver

--- a/lib/Algebra/FunctionProperties/NP.agda
+++ b/lib/Algebra/FunctionProperties/NP.agda
@@ -55,16 +55,16 @@ Zero : A → Op₂ A → Set _
 Zero z · = LeftZero z · × RightZero z ·
 
 LeftInverse : A → Op₁ A → Op₂ A → Set _
-LeftInverse e _⁻¹ _·_ = ∀₁ λ x → x ⁻¹ · x ≈ e
+LeftInverse e _⁻¹ _·_ = ∀₁ λ x → (x ⁻¹) · x ≈ e
 
 LeftInverseNonZero : (zero e : A) → Op₁ A → Op₂ A → Set _
-LeftInverseNonZero zero e _⁻¹ _·_ = ∀₁ λ x → x ≉ zero → x ⁻¹ · x ≈ e
+LeftInverseNonZero zero e _⁻¹ _·_ = ∀₁ λ x → x ≉ zero → (x ⁻¹) · x ≈ e
 
 RightInverse : A → Op₁ A → Op₂ A → Set _
-RightInverse e _⁻¹ _·_ = ∀₁ λ x → x · x ⁻¹ ≈ e
+RightInverse e _⁻¹ _·_ = ∀₁ λ x → x · (x ⁻¹) ≈ e
 
 RightInverseNonZero : (zero e : A) → Op₁ A → Op₂ A → Set _
-RightInverseNonZero zero e _⁻¹ _·_ = ∀₁ λ x → x ≉ zero → x · x ⁻¹ ≈ e
+RightInverseNonZero zero e _⁻¹ _·_ = ∀₁ λ x → x ≉ zero → x · (x ⁻¹) ≈ e
 
 Inverse : A → Op₁ A → Op₂ A → Set _
 Inverse e ⁻¹ · = LeftInverse e ⁻¹ · × RightInverse e ⁻¹ ·
@@ -121,7 +121,7 @@ module Morphisms {b ℓᴮ}{B : Set b}(_≈ᴮ_ : Rel B ℓᴮ)(⟦_⟧ : A → 
   Homomorphic₀ ∙ ∘ = ⟦ ∙ ⟧ ≈ᴮ ∘
 
   Homomorphic₁ : Fun₁ A → Op₁ B → Set _
-  Homomorphic₁ ∙_ ∘_ = ∀₁ λ x → ⟦ ∙ x ⟧ ≈ᴮ ∘ ⟦ x ⟧
+  Homomorphic₁ ∙_ ∘_ = ∀₁ λ x → ⟦ ∙ x ⟧ ≈ᴮ (∘ ⟦ x ⟧)
 
   Homomorphic₂ : Fun₂ A → Op₂ B → Set _
   Homomorphic₂ _∙_ _∘_ =

--- a/lib/Algebra/Raw.agda
+++ b/lib/Algebra/Raw.agda
@@ -83,7 +83,7 @@ module Additive-Monoid-Ops {ℓ}{M : Set ℓ} (mon : Monoid-Ops M) where
              ; ∙-magma to +-magma
              )
   open M public using (0#; +-magma)
-  open module +-magma = Additive-Magma +-magma public
+  open Additive-Magma +-magma public
   infixl 7 _⊗⁺_
   _⊗⁺_  = M._⊗⁺_
 
@@ -152,7 +152,7 @@ module Additive-Group-Ops {ℓ}{G : Type ℓ} (grp : Group-Ops G) where
              ; /′= to −′=
              )
   open M public using (0−_; +-mon-ops; −=; 0−=)
-  open module +-mon-ops = Additive-Monoid-Ops +-mon-ops public
+  open Additive-Monoid-Ops +-mon-ops public
   infixl 6 _−_
   infixl 7 _⊗⁻_ _⊗_
   _−_   = M._−_

--- a/lib/Data/Maybe/NP.agda
+++ b/lib/Data/Maybe/NP.agda
@@ -239,13 +239,13 @@ module FunctorLemmas {a} where
   <$>-injective₁ : ∀ {A B}
                      {f : A → B} {x y : Maybe A}
                      (f-inj : ∀ {x y} → f x ≡ f y → x ≡ y)
-                   → f <$> x ≡ f <$> y → x ≡ y
+                   → (f <$> x) ≡ (f <$> y) → x ≡ y
   <$>-injective₁ {x = just _}  {just _}  f-inj eq = ≡.cong just (f-inj (just-injective eq))
   <$>-injective₁ {x = nothing} {nothing} _     _  = ≡.refl
   <$>-injective₁ {x = just _}  {nothing} _     ()
   <$>-injective₁ {x = nothing} {just _}  _     ()
 
-  <$>-assoc : ∀ {A B C} {f : A → B} {g : C → A} (x : Maybe C) → f ∘ g <$> x ≡ f <$> (g <$> x)
+  <$>-assoc : ∀ {A B C} {f : A → B} {g : C → A} (x : Maybe C) → (f ∘ g <$> x) ≡ (f <$> (g <$> x))
   <$>-assoc (just _) = ≡.refl
   <$>-assoc nothing  = ≡.refl
 
@@ -255,11 +255,11 @@ module MonadLemmas {a} where
  --  open RawApplicative applicative public
 
   cong-Maybe : ∀ {A B}
-                 (f : A → B) {x y} → x ≡ pure y → f <$> x ≡ pure (f y)
+                 (f : A → B) {x y} → x ≡ pure y → (f <$> x) ≡ pure (f y)
   cong-Maybe f ≡.refl = ≡.refl
 
   cong₂-Maybe : ∀ {A B C}
-                  (f : A → B → C) {x y u v} → x ≡ pure y → u ≡ pure v → pure f ⊛ x ⊛ u ≡ pure (f y v)
+                  (f : A → B → C) {x y u v} → x ≡ pure y → u ≡ pure v → (pure f ⊛ x ⊛ u) ≡ pure (f y v)
   cong₂-Maybe f ≡.refl ≡.refl = ≡.refl
 
   Maybe-comm-monad :
@@ -271,13 +271,13 @@ module MonadLemmas {a} where
   Maybe-comm-monad {x = just _}  {nothing}  = ≡.refl
   Maybe-comm-monad {x = just _}  {just _}   = ≡.refl
 
-  Maybe-comm-appl : ∀ {A B} {f : Maybe (A → B)} {x} → f ⊛ x ≡ (flip _$_) <$> x ⊛ f
+  Maybe-comm-appl : ∀ {A B} {f : Maybe (A → B)} {x} → (f ⊛ x) ≡ ((flip _$_) <$> x ⊛ f)
   Maybe-comm-appl {f = nothing} {nothing}  = ≡.refl
   Maybe-comm-appl {f = nothing} {just _}   = ≡.refl
   Maybe-comm-appl {f = just _}  {nothing}  = ≡.refl
   Maybe-comm-appl {f = just _}  {just _}   = ≡.refl
 
-  Maybe-comm-appl₂ : ∀ {A B C} {f : A → B → C} {x y} → f <$> x ⊛ y ≡ flip f <$> y ⊛ x
+  Maybe-comm-appl₂ : ∀ {A B C} {f : A → B → C} {x y} → (f <$> x ⊛ y) ≡ (flip f <$> y ⊛ x)
   Maybe-comm-appl₂ {x = nothing} {nothing}  = ≡.refl
   Maybe-comm-appl₂ {x = nothing} {just _}   = ≡.refl
   Maybe-comm-appl₂ {x = just _}  {nothing}  = ≡.refl

--- a/lib/Relation/Binary/NP.agda
+++ b/lib/Relation/Binary/NP.agda
@@ -54,7 +54,7 @@ module Refl-Trans-Reasoning
          (trans : Transitive _≈_) where
 
   open Trans-Reasoning _≈_ trans public hiding (finally)
-  infix  2 _∎
+  infix  3 _∎
 
   _∎ : ∀ x → x ≈ x
   _ ∎ = refl

--- a/lib/Relation/Binary/PropositionalEquality/NP.agda
+++ b/lib/Relation/Binary/PropositionalEquality/NP.agda
@@ -7,3 +7,21 @@ open import Relation.Binary.PropositionalEquality
 
 open import Relation.Binary.PropositionalEquality.Base
   public
+
+open import Function.Param.Binary
+open import Type.Param.Binary
+
+data ⟦≡⟧ {a₀ a₁ aᵣ}
+         {A₀ A₁} (Aᵣ : ⟦★⟧ {a₀} {a₁} aᵣ A₀ A₁)
+         {x₀ x₁} (xᵣ : Aᵣ x₀ x₁)
+       : (Aᵣ ⟦→⟧ ⟦★⟧ aᵣ) (_≡_ x₀) (_≡_ x₁) where
+    -- : ∀ {y₀ y₁} (yᵣ : Aᵣ y₀ y₁) → x₀ ≡ y₀ → x₁ ≡ y₁ → ★
+  ⟦refl⟧ : ⟦≡⟧ Aᵣ xᵣ xᵣ refl refl
+
+-- Double checking level 0 with a direct ⟦_⟧ encoding
+private
+  ⟦≡⟧′ : (∀⟨ Aᵣ ∶ ⟦★₀⟧ ⟩⟦→⟧ Aᵣ ⟦→⟧ Aᵣ ⟦→⟧ ⟦★₀⟧) _≡_ _≡_
+  ⟦≡⟧′ = ⟦≡⟧
+
+  ⟦refl⟧′ : (∀⟨ Aᵣ ∶ ⟦★₀⟧ ⟩⟦→⟧ ∀⟨ xᵣ ∶ Aᵣ ⟩⟦→⟧ ⟦≡⟧ Aᵣ xᵣ xᵣ) refl refl
+  ⟦refl⟧′ _ _ = ⟦refl⟧


### PR DESCRIPTION
The definition of `⟦≡⟧` was deleted from `Relation.Binary.PropositionalEquality.NP` in https://github.com/crypto-agda/agda-nplib/commit/f9c707c77a64e5a4143781a11ddba4cc4e510903, but it’s still needed by the NomPa library; e.g. in [`NomPa/Implem/LogicalRelation/Internals`](https://github.com/np/NomPa/blob/master/lib/NomPa/Implem/LogicalRelation/Internals.agda).

Needed for https://github.com/np/NomPa/issues/1. Should be merged after #3.
